### PR TITLE
Import cycle from itertools for joke iteration functionality

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.security.utils import get_authorization_scheme_param
 from fastapi.responses import JSONResponse
 from mcp.server.fastmcp import FastMCP
+from itertools import cycle
 # from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 # from typing import Optional


### PR DESCRIPTION
This pull request includes a small change to the `server.py` file. The change involves importing the `cycle` function from the `itertools` module.

* [`server.py`](diffhunk://#diff-791d4d41d3718d15d49180f3aacc8370b8cab07383f0d35b2713651cc0adfe46R5): Added import for `cycle` from `itertools` module.